### PR TITLE
Fix compilation and linking issues when building on Windows, using MSVC.

### DIFF
--- a/example/CustomProxyFactory.cpp
+++ b/example/CustomProxyFactory.cpp
@@ -4,4 +4,6 @@
 
 std::shared_ptr<libmexclass::proxy::Proxy> CustomProxyFactory::make_proxy(const libmexclass::proxy::ClassName& class_name, const libmexclass::proxy::FunctionArguments& constructor_arguments) {
     registerProxy(CarProxy);
+    // TODO: Handle case where input class name does not match any of the registered proxy classes.
+    return nullptr;
 }

--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.0.0)
 set(LIBMEXCLASS_PROJECT_NAME libmexclass)
 project(${LIBMEXCLASS_PROJECT_NAME} VERSION 0.1.0)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 # Find MATLAB.
 find_package(Matlab REQUIRED)
 

--- a/libmexclass/cpp/source/include/libmexclass/action/Create.h
+++ b/libmexclass/cpp/source/include/libmexclass/action/Create.h
@@ -12,7 +12,8 @@ namespace libmexclass::action {
         public:
             Create(libmexclass::mex::State& state, std::shared_ptr<proxy::Factory> proxy_factory) : Action{state}, proxy_factory{proxy_factory} {
                 // TODO: Implement input validation.
-                class_name = std::string(state.inputs[libmexclass::action::Create::CLASS_NAME_INDEX][0]);
+                // TODO: Consider whether this needs to be UTF-16
+                class_name = matlab::engine::convertUTF16StringToUTF8String(state.inputs[libmexclass::action::Create::CLASS_NAME_INDEX][0]);
                 // TODO: This should be a cell array, correct?
                 constructor_arguments = state.inputs[libmexclass::action::Create::CONSTRUCTOR_ARGUMENTS_INDEX];
             }

--- a/libmexclass/cpp/source/include/libmexclass/action/Factory.h
+++ b/libmexclass/cpp/source/include/libmexclass/action/Factory.h
@@ -22,8 +22,8 @@ namespace libmexclass::action {
         }
         std::unique_ptr<Action> makeAction(libmexclass::mex::State& state) {
             // TODO: Implement input validation and parsing logic.
-            // TODO: Check on string encoding.
-            const auto action_type_string = std::string(state.inputs[0][0]);
+            // TODO: Check on string encoding, consider whether it should be UTF-16
+            const auto action_type_string =  matlab::engine::convertUTF16StringToUTF8String(state.inputs[0][0]);
             const libmexclass::action::TypeFactory type_factory;
             const auto action_type = type_factory.make_type(action_type_string);
             switch (action_type) {

--- a/libmexclass/cpp/source/include/libmexclass/action/MethodCall.h
+++ b/libmexclass/cpp/source/include/libmexclass/action/MethodCall.h
@@ -12,7 +12,8 @@ namespace libmexclass::action {
         public:
             MethodCall(libmexclass::mex::State& state) : Action{state} {
                 proxy_id = std::uint64_t(state.inputs[libmexclass::action::MethodCall::PROXY_ID_INDEX][0]);
-                method_name = std::string(state.inputs[libmexclass::action::MethodCall::METHOD_NAME_INDEX][0]);
+                // TODO: Consider whether this should be UTF-16
+                method_name = matlab::engine::convertUTF16StringToUTF8String(state.inputs[libmexclass::action::MethodCall::METHOD_NAME_INDEX][0]);
                 method_arguments = state.inputs[libmexclass::action::MethodCall::METHOD_ARGUMENTS_INDEX];
             }
             virtual ~MethodCall() {}


### PR DESCRIPTION
1. Specify encoding when converting from MDA strings from MATLAB to std::string values. 
2. Export symbols on Windows to create mexclass.lib.
3. Add default return statement to CustomProxyFactory.cpp.

Closes #7 