### PR TITLE
Make the proxy manager more thread safe

### DIFF
--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -1,33 +1,34 @@
 #pragma once
 
-#include "libmexclass/proxy/Proxy.h"
 #include "libmexclass/proxy/ID.h"
+#include "libmexclass/proxy/Proxy.h"
 
-#include <unordered_map>
 #include <memory>
+#include <unordered_map>
 
 namespace libmexclass::proxy {
-	// ProxyMangager
-	// Manages Proxy instances by placing them inside of a map which maps unique IDs to Proxy instances.
-	// NOTE: ProxyManager uses the "Singleton" design pattern to ensure there is only ever one ProxyManager instance.
-	class ProxyManager {
-		public:
-			ID manageProxy(std::shared_ptr<Proxy> proxy);
-			void unmanageProxy(ID id);
-			std::shared_ptr<Proxy> getProxy(ID id);
-			static std::shared_ptr<ProxyManager> getProxyManager();
-		private:
-			// The internal map used to associate Proxy instances with unique IDs.
-			std::unordered_map<ID, std::shared_ptr<Proxy>> proxy_map;
+// ProxyMangager
+// Manages Proxy instances by placing them inside of a map which maps unique IDs
+// to Proxy instances. NOTE: ProxyManager uses the "Singleton" design pattern to
+// ensure there is only ever one ProxyManager instance.
+class ProxyManager {
+  public:
+    static ID manageProxy(const std::shared_ptr<Proxy> &proxy);
+    static void unmanageProxy(ID id);
+    static std::shared_ptr<Proxy> getProxy(ID id);
 
-			// TODO: Consider whether it makes sense to "recycle" deleted IDs:
-			//
-			// 1. Whenever an ID is deleted, enqueue it into an queue of recycled IDs.
-			// 2. The getNextId() method should first check if the queue has any recycled IDs in it. If so, dequeue the first one and use it.
-			// 3. If the queue is empty, use the value of "current_id" and then increment it.
-			ID current_proxy_id = 0;
+  private:
+    static ProxyManager singleton;
+    // The internal map used to associate Proxy instances with unique IDs.
+    std::unordered_map<ID, std::shared_ptr<Proxy>> proxy_map;
 
-			// static singleton ProxyManager instance.
-			static inline std::shared_ptr<ProxyManager> instance = nullptr;
-	};
-}
+    // TODO: Consider whether it makes sense to "recycle" deleted IDs:
+    //
+    // 1. Whenever an ID is deleted, enqueue it into an queue of recycled IDs.
+    // 2. The getNextId() method should first check if the queue has any
+    //    recycled IDs in it. If so, dequeue the first one and use it.
+    // 3. If the queue is empty, use the value of "current_id" and then
+    //    increment it.
+    ID current_proxy_id = 0;
+};
+} // namespace libmexclass::proxy

--- a/libmexclass/cpp/source/libmexclass/action/Create.cpp
+++ b/libmexclass/cpp/source/libmexclass/action/Create.cpp
@@ -8,16 +8,19 @@
 
 namespace libmexclass::action {
 
-        void Create::execute() {
-            // proxy::ProxyFactory will create an appropriate proxy::Proxy subclass based on the provided libmexclass::mex::State.
-            std::shared_ptr<libmexclass::proxy::Proxy> proxy = proxy_factory->make_proxy(class_name, constructor_arguments);
+void Create::execute() {
+    // proxy::ProxyFactory will create an appropriate proxy::Proxy subclass
+    // based on the provided libmexclass::mex::State.
+    std::shared_ptr<libmexclass::proxy::Proxy> proxy =
+        proxy_factory->make_proxy(class_name, constructor_arguments);
 
-            // Assign the proxy::ID returned by the ProxyManager to the outputs[] MDA.
-            libmexclass::proxy::ID id = libmexclass::proxy::ProxyManager::getProxyManager()->manageProxy(proxy);
+    // Assign the proxy::ID returned by the ProxyManager to the outputs[] MDA.
+    libmexclass::proxy::ID id =
+        libmexclass::proxy::ProxyManager::manageProxy(proxy);
 
-            matlab::data::ArrayFactory factory;
-            auto id_array = factory.createScalar<libmexclass::proxy::ID>(id);
-            outputs[0] = id_array;
-        }
-        
+    matlab::data::ArrayFactory factory;
+    auto id_array = factory.createScalar<libmexclass::proxy::ID>(id);
+    outputs[0] = id_array;
 }
+
+} // namespace libmexclass::action

--- a/libmexclass/cpp/source/libmexclass/action/Destroy.cpp
+++ b/libmexclass/cpp/source/libmexclass/action/Destroy.cpp
@@ -5,11 +5,12 @@
 
 namespace libmexclass::action {
 
-        void Destroy::execute() {
-            // Remove the proxy::Proxy instance specified by the given proxy::ID from the proxy::ProxyManager.
-            // This should also deallocate any associated memory (unless there is a shared_ptr to the proxy
-            // being held somewhere else).
-            libmexclass::proxy::ProxyManager::getProxyManager()->unmanageProxy(proxy_id);
-        }
-
+void Destroy::execute() {
+    // Remove the proxy::Proxy instance specified by the given proxy::ID from
+    // the proxy::ProxyManager. This should also deallocate any associated
+    // memory (unless there is a shared_ptr to the proxy being held somewhere
+    // else).
+    libmexclass::proxy::ProxyManager::unmanageProxy(proxy_id);
 }
+
+} // namespace libmexclass::action

--- a/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
+++ b/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
@@ -7,16 +7,21 @@
 
 namespace libmexclass::action {
 
-        void MethodCall::execute() {
-            // TODO: Implement ID retrieval logic from MethodCall properties.
-            // Retrieve the appropriate polymorphic proxy::Proxy instance from the proxy::ProxyManager using the given proxy::ID.
-            std::shared_ptr<libmexclass::proxy::Proxy> proxy = libmexclass::proxy::ProxyManager::getProxyManager()->getProxy(proxy_id);
-            
-            // Invoke the appropriate method on the proxy::Proxy instance.
-            // Note: To assign/return outputs from a method call, proxy::Proxy instances can assign to state.outputs (which is a std::vector<matlab::data::Array>).
-            // TODO: Consider passing method_arguments to proxy instead. 
-            libmexclass::proxy::method::Method method{method_name, method_arguments, outputs, matlab};
-            proxy->invoke(method);
-        }
+void MethodCall::execute() {
+    // TODO: Implement ID retrieval logic from MethodCall properties.
+    // Retrieve the appropriate polymorphic proxy::Proxy instance from the
+    // proxy::ProxyManager using the given proxy::ID.
+    std::shared_ptr<libmexclass::proxy::Proxy> proxy =
+        libmexclass::proxy::ProxyManager::getProxy(proxy_id);
 
+    // Invoke the appropriate method on the proxy::Proxy instance.
+    // Note: To assign/return outputs from a method call, proxy::Proxy
+    // instances can assign to state.outputs ( which is a
+    // std::vector<matlab::data::Array>).
+    // TODO: Consider passing method_arguments to proxy instead.
+    libmexclass::proxy::method::Method method{method_name, method_arguments,
+                                              outputs, matlab};
+    proxy->invoke(method);
 }
+
+} // namespace libmexclass::action

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -2,28 +2,19 @@
 
 namespace libmexclass::proxy {
 
-	ID ProxyManager::manageProxy(std::shared_ptr<Proxy> proxy) {
-		const ID proxy_id = this->current_proxy_id;
-		this->proxy_map[proxy_id] = proxy;
-		this->current_proxy_id++;
-		return proxy_id;
-	}
-
-	void ProxyManager::unmanageProxy(ID id) {
-		this->proxy_map.erase(id);
-	}
-
-	std::shared_ptr<Proxy> ProxyManager::getProxy(ID id) {
-		return proxy_map[id];
-	}
-
-	// Uses the "Singleton" design pattern to ensure only one instance of the ProxyManager ever exists.
-	std::shared_ptr<ProxyManager> ProxyManager::getProxyManager() {
-		if (!instance) {
-            instance = std::make_shared<ProxyManager>();
-			return instance;
-		}
-		return instance;
-	}
-
+ID ProxyManager::manageProxy(const std::shared_ptr<Proxy> &proxy) {
+    const ID proxy_id = ProxyManager::singleton.current_proxy_id++;
+    ProxyManager::singleton.proxy_map[proxy_id] = proxy;
+    return proxy_id;
 }
+
+void ProxyManager::unmanageProxy(ID id) {
+    ProxyManager::singleton.proxy_map.erase(id);
+}
+
+std::shared_ptr<Proxy> ProxyManager::getProxy(ID id) {
+    return ProxyManager::singleton.proxy_map[id];
+}
+
+ProxyManager ProxyManager::singleton{};
+} // namespace libmexclass::proxy


### PR DESCRIPTION
I updated ProxyManager to use a slightly different paradigm. 

It uses a static property to maintain the registered Proxies instead of a per instance property. That shouldn't make any difference since ProxyManager is a singleton anyway. This also has the effect on ensuring only one construction.

Then, since there wasn't much reason to operate directly on the instance, I made the methods static, which further hides the singleton, that really didn't improve thread safety, but it's nice.

Finally, I made the ID property an atomic to avoid multiple threads trying to update it. This might have some performance impact, but I don't think registering new proxies at a high rate of speed is required. 