### PR TITLE
Closes #45

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "libmexclass"
 on: [push]
 jobs:
-    build-libmexclass:
+    linux:
         runs-on: ubuntu-latest
         env:
             LIBMEXCLASS_INSTALL_PREFIX: "/home/runner/work/install"
@@ -25,5 +25,25 @@ jobs:
                   # This version of libstdc++ is incompatible with the system version of libstdc++.
                   # As a workaround, set LD_PRELOAD to use the system version of libstdc++ with MATLAB.
                   LD_PRELOAD: ${{ env.SYSTEM_LIBSTDCPP_PATH }}
+              with:
+                  command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
+    mac:
+        runs-on: macos-latest
+        env:
+            LIBMEXCLASS_INSTALL_PREFIX: "/home/runner/work/install"
+            # Use the commit SHA that triggered the workflow to run the example on latest changes.
+            LIBMEXCLASS_GIT_TAG: $(git rev-parse --short "$GITHUB_SHA")
+        steps:
+            - name: Download libmexclass source code
+              uses: actions/checkout@v3
+            - name: Install MATLAB
+              uses: matlab-actions/setup-matlab@v1
+            - name: Build Example
+              run: |
+                  cd example
+                  cmake -S . -B build -D CMAKE_INSTALL_PREFIX=${{ env.LIBMEXCLASS_INSTALL_PREFIX }} -D LIBMEXCLASS_FETCH_CONTENT_GIT_TAG=${{ env.LIBMEXCLASS_GIT_TAG }}
+                  cmake --build build --config Release --target install
+            - name: Run Example
+              uses: matlab-actions/run-command@v1
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     mac:
         runs-on: macos-latest
         env:
-            LIBMEXCLASS_INSTALL_PREFIX: "/home/runner/work/install"
+            LIBMEXCLASS_INSTALL_PREFIX: "~/install"
             # Use the commit SHA that triggered the workflow to run the example on latest changes.
             LIBMEXCLASS_GIT_TAG: $(git rev-parse --short "$GITHUB_SHA")
         steps:


### PR DESCRIPTION
# Overview

This pull request makes the following changes:

1. Closes #45
2. This pull request adds a GitHub Actions workflow for `macOS` (named `mac`).
3. Renames the existing Ubuntu-based CI workflow `build-libmexclass` to `linux`.

# Future Directions

1. #46

# Notes

1. Thanks @sgilmore10 for your help with this pull request!