### PR TITLE
Closes #62: `ProxyManager::getProxy` adds elements to the map if the input `ID` doesn't already exist.

### DIFF
--- a/libmexclass/cpp/source/include/libmexclass/proxy/Proxy.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/Proxy.h
@@ -28,6 +28,9 @@ namespace libmexclass::proxy {
 	class Proxy {
 		public:
             Proxy() : methods{} { }
+
+            virtual ~Proxy() {}
+
 			std::optional<libmexclass::error::Error> invoke(libmexclass::proxy::method::Method& method);
         protected:
             std::unordered_map<libmexclass::proxy::method::Name, libmexclass::proxy::method::Object> methods;

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -20,8 +20,6 @@ class ProxyManager {
   public:
     static ID manageProxy(const std::shared_ptr<Proxy> &proxy);
     static void unmanageProxy(ID id);
-    static ProxyResult getProxy(ID id);
-
     static std::shared_ptr<Proxy> getProxy(ID id);
 
   private:

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -11,7 +11,7 @@
 namespace libmexclass::proxy {
 
 template <typename T>
-using ProxyResult<T> = std::variant<std::shared_ptr<T>, libmexclass::error::Error>;
+using ProxyResult = std::variant<std::shared_ptr<T>, libmexclass::error::Error>;
 
 // ProxyMangager
 // Manages Proxy instances by placing them inside of a map which maps unique IDs

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -10,7 +10,8 @@
 
 namespace libmexclass::proxy {
 
-using ProxyResult = std::variant<std::shared_ptr<Proxy>, libmexclass::error::Error>;
+template <typename T>
+using ProxyResult<T> = std::variant<std::shared_ptr<T>, libmexclass::error::Error>;
 
 // ProxyMangager
 // Manages Proxy instances by placing them inside of a map which maps unique IDs

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -21,6 +21,27 @@ class ProxyManager {
     static ID manageProxy(const std::shared_ptr<Proxy> &proxy);
     static void unmanageProxy(ID id);
     static ProxyResult getProxy(ID id);
+    
+    
+    
+    template <typename T = libmexclass::proxy::Proxy>
+    static std::shared_ptr<T> getProxy(ID id) {
+        auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
+        if (proxy_key_value == ProxyManager::singleton.proxy_map.end()) {
+            return nullptr;
+        }
+        auto typed_proxy = std::dynamic_pointer_cast<T>(proxy_key_value->second);
+        return typed_proxy;
+    }
+    
+    template <>
+    static std::shared_ptr<libmexclass::proxy::Proxy> getProxy(ID id) {
+        auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
+        if (proxy_key_value == ProxyManager::singleton.proxy_map.end()) {
+            return nullptr;
+        }
+        auto proxy_key_value->second;
+    }
 
   private:
     static ProxyManager singleton;

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -43,7 +43,7 @@ ProxyResult getProxy(ID id) {
     // TODO: update getProxy to return a "result"
     auto proxy = libmexclass::proxy::ProxyManager::getProxy(id);
     if (!proxy) {
-        std::string msg = "Invalid Proxy ID: " + std::string(id);
+        std::string msg = "Invalid Proxy ID: " + std::to_string(id);
         return libmexclass::error::Error{"libmexclass:proxy:InvalidID", msg};
     }
 

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -21,27 +21,8 @@ class ProxyManager {
     static ID manageProxy(const std::shared_ptr<Proxy> &proxy);
     static void unmanageProxy(ID id);
     static ProxyResult getProxy(ID id);
-    
-    
-    
-    template <typename T = libmexclass::proxy::Proxy>
-    static std::shared_ptr<T> getProxy(ID id) {
-        auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
-        if (proxy_key_value == ProxyManager::singleton.proxy_map.end()) {
-            return nullptr;
-        }
-        auto typed_proxy = std::dynamic_pointer_cast<T>(proxy_key_value->second);
-        return typed_proxy;
-    }
-    
-    template <>
-    static std::shared_ptr<libmexclass::proxy::Proxy> getProxy(ID id) {
-        auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
-        if (proxy_key_value == ProxyManager::singleton.proxy_map.end()) {
-            return nullptr;
-        }
-        return proxy_key_value->second;
-    }
+
+    static std::shared_ptr<Proxy> getProxy(ID id);
 
   private:
     static ProxyManager singleton;

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -2,11 +2,16 @@
 
 #include "libmexclass/proxy/ID.h"
 #include "libmexclass/proxy/Proxy.h"
+#include "libmexclass/error/Error.h"
 
 #include <memory>
 #include <unordered_map>
+#include <variant>
 
 namespace libmexclass::proxy {
+
+using ProxyResult = std::variant<std::shared_ptr<Proxy>, libmexclass::error::Error>;
+
 // ProxyMangager
 // Manages Proxy instances by placing them inside of a map which maps unique IDs
 // to Proxy instances. NOTE: ProxyManager uses the "Singleton" design pattern to
@@ -15,7 +20,7 @@ class ProxyManager {
   public:
     static ID manageProxy(const std::shared_ptr<Proxy> &proxy);
     static void unmanageProxy(ID id);
-    static std::shared_ptr<Proxy> getProxy(ID id);
+    static ProxyResult getProxy(ID id);
 
   private:
     static ProxyManager singleton;

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -32,7 +32,7 @@ class ProxyManager {
 
         auto typed_proxy = std::dynamic_pointer_cast<T>(proxy);
         if (!typed_proxy) {
-            std::string msg = "Unable to cast proxy to " + T::class_name;
+            std::string msg = "Failed to cast proxy to expected type";
             return libmexclass::error::Error{"libmexclass:proxy:InvalidProxyType", msg};
         }
 

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -23,7 +23,7 @@ class ProxyManager {
     static std::shared_ptr<Proxy> getProxy(ID id);
 
     template <typename T>
-    static ProxyResult getTypedProxy(ID id) {
+    static ProxyResult<T> getTypedProxy(ID id) {
         auto proxy = libmexclass::proxy::ProxyManager::getProxy(id);
         if (!proxy) {
             std::string msg = "Invalid Proxy ID: " + std::to_string(id);

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -22,6 +22,23 @@ class ProxyManager {
     static void unmanageProxy(ID id);
     static std::shared_ptr<Proxy> getProxy(ID id);
 
+    template <typename T>
+    static ProxyResult getTypedProxy(ID id) {
+        auto proxy = libmexclass::proxy::ProxyManager::getProxy(id);
+        if (!proxy) {
+            std::string msg = "Invalid Proxy ID: " + std::to_string(id);
+            return libmexclass::error::Error{"libmexclass:proxy:InvalidID", msg};
+        }
+
+        auto typed_proxy = std::dynamic_pointer_cast<T>(proxy);
+        if (!typed_proxy) {
+            std::string msg = "Unable to cast proxy to " + T::class_name;
+            return libmexclass::error::Error{"libmexclass:proxy:InvalidProxyType", msg};
+        }
+
+        return typed_proxy;
+    }
+
   private:
     static ProxyManager singleton;
     // The internal map used to associate Proxy instances with unique IDs.
@@ -36,22 +53,5 @@ class ProxyManager {
     //    increment it.
     ID current_proxy_id = 0;
 };
-
-template <typename T>
-ProxyResult getProxy(ID id) {
-
-    // TODO: update getProxy to return a "result"
-    auto proxy = libmexclass::proxy::ProxyManager::getProxy(id);
-    if (!proxy) {
-        std::string msg = "Invalid Proxy ID: " + std::to_string(id);
-        return libmexclass::error::Error{"libmexclass:proxy:InvalidID", msg};
-    }
-
-    auto typed_proxy = std::dynamic_pointer_cast<T>(proxy);
-    if (!typed_proxy) {
-        std::string msg = "Unable to cast proxy to " + T::class_name;
-        return libmexclass::error::Error{"libmexclass:proxy:InvalidProxyType", msg};
-    }
-}
 
 } // namespace libmexclass::proxy

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -36,4 +36,22 @@ class ProxyManager {
     //    increment it.
     ID current_proxy_id = 0;
 };
+
+template <typename T>
+ProxyResult getProxy(ID id) {
+
+    // TODO: update getProxy to return a "result"
+    auto proxy = libmexclass::proxy::ProxyManager::getProxy(id);
+    if (!proxy) {
+        std::string msg = "Invalid Proxy ID: " + std::string(id);
+        return libmexclass::error::Error{"libmexclass:proxy:InvalidID", msg};
+    }
+
+    auto typed_proxy = std::dynamic_pointer_cast<T>(proxy);
+    if (!typed_proxy) {
+        std::string msg = "Unable to cast proxy to " + T::class_name;
+        return libmexclass::error::Error{"libmexclass:proxy:InvalidProxyType", msg};
+    }
+}
+
 } // namespace libmexclass::proxy

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -40,7 +40,7 @@ class ProxyManager {
         if (proxy_key_value == ProxyManager::singleton.proxy_map.end()) {
             return nullptr;
         }
-        auto proxy_key_value->second;
+        return proxy_key_value->second;
     }
 
   private:

--- a/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
+++ b/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
@@ -11,11 +11,10 @@ std::optional<libmexclass::error::Error> MethodCall::execute() {
     // TODO: Implement ID retrieval logic from MethodCall properties.
     // Retrieve the appropriate polymorphic proxy::Proxy instance from the
     // proxy::ProxyManager using the given proxy::ID.
-    libmexclass::proxy::ProxyResult maybe_proxy =
-        libmexclass::proxy::ProxyManager::getProxy(proxy_id);
+    auto proxy = libmexclass::proxy::ProxyManager::getProxy(proxy_id);
 
-    if (std::holds_alternative<libmexclass::error::Error>(maybe_proxy)) {
-        return std::get<libmexclass::error::Error>(maybe_proxy);
+    if (!proxy) {
+        return libmexclass::error::Error{"libmexclass:proxy:UnknownProxyID", "Unknown proxy ID " + std::to_string(proxy_id)};
     }
 
     auto proxy = std::get<std::shared_ptr<libmexclass::proxy::Proxy>>(std::move(maybe_proxy));

--- a/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
+++ b/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
@@ -17,8 +17,6 @@ std::optional<libmexclass::error::Error> MethodCall::execute() {
         return libmexclass::error::Error{"libmexclass:proxy:UnknownProxyID", "Unknown proxy ID " + std::to_string(proxy_id)};
     }
 
-    auto proxy = std::get<std::shared_ptr<libmexclass::proxy::Proxy>>(std::move(maybe_proxy));
-
     // Invoke the appropriate method on the proxy::Proxy instance.
     // Note: To assign/return outputs from a method call, proxy::Proxy
     // instances can assign to state.outputs ( which is a

--- a/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
+++ b/libmexclass/cpp/source/libmexclass/action/MethodCall.cpp
@@ -11,8 +11,14 @@ std::optional<libmexclass::error::Error> MethodCall::execute() {
     // TODO: Implement ID retrieval logic from MethodCall properties.
     // Retrieve the appropriate polymorphic proxy::Proxy instance from the
     // proxy::ProxyManager using the given proxy::ID.
-    std::shared_ptr<libmexclass::proxy::Proxy> proxy =
+    libmexclass::proxy::ProxyResult maybe_proxy =
         libmexclass::proxy::ProxyManager::getProxy(proxy_id);
+
+    if (std::holds_alternative<libmexclass::error::Error>(maybe_proxy)) {
+        return std::get<libmexclass::error::Error>(maybe_proxy);
+    }
+
+    auto proxy = std::get<std::shared_ptr<libmexclass::proxy::Proxy>>(std::move(maybe_proxy));
 
     // Invoke the appropriate method on the proxy::Proxy instance.
     // Note: To assign/return outputs from a method call, proxy::Proxy

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -12,8 +12,14 @@ void ProxyManager::unmanageProxy(ID id) {
     ProxyManager::singleton.proxy_map.erase(id);
 }
 
-std::shared_ptr<Proxy> ProxyManager::getProxy(ID id) {
-    return ProxyManager::singleton.proxy_map[id];
+ProxyResult ProxyManager::getProxy(ID id) {
+    auto proxy_key_value = ProxyManager::singleton.proxy_map.at(id);
+    if (proxy_key_value->first != ProxyManager::singleton.proxy_map.end()) {
+        return proxy_key_value->second;
+    } else {
+        const std::string msg = "Unknown Proxy ID: " + std::to_string(id);
+        return libmexclass::error::Error{"libmexclass:proxy:UnknownID", msg};
+    }
 }
 
 ProxyManager ProxyManager::singleton{};

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -14,11 +14,11 @@ void ProxyManager::unmanageProxy(ID id) {
 
 ProxyResult ProxyManager::getProxy(ID id) {
     auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
-    if (proxy_key_value->first != ProxyManager::singleton.proxy_map.end()) {
-        return proxy_key_value->second;
-    } else {
+    if (proxy_key_value->first == ProxyManager::singleton.proxy_map.end()) {
         const std::string msg = "Unknown Proxy ID: " + std::to_string(id);
         return libmexclass::error::Error{"libmexclass:proxy:UnknownID", msg};
+    } else {
+        return proxy_key_value->second;
     }
 }
 

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -12,15 +12,15 @@ void ProxyManager::unmanageProxy(ID id) {
     ProxyManager::singleton.proxy_map.erase(id);
 }
 
-ProxyResult ProxyManager::getProxy(ID id) {
-    auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
-    if (proxy_key_value != ProxyManager::singleton.proxy_map.end()) {
-        return proxy_key_value->second;
-    } else {
-        const std::string msg = "Unknown Proxy ID: " + std::to_string(id);
-        return libmexclass::error::Error{"libmexclass:proxy:UnknownID", msg};
-    }
-}
+//ProxyResult ProxyManager::getProxy(ID id) {
+//    auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
+//    if (proxy_key_value != ProxyManager::singleton.proxy_map.end()) {
+//        return proxy_key_value->second;
+//    } else {
+//        const std::string msg = "Unknown Proxy ID: " + std::to_string(id);
+//        return libmexclass::error::Error{"libmexclass:proxy:UnknownID", msg};
+//    }
+//}
 
 ProxyManager ProxyManager::singleton{};
 } // namespace libmexclass::proxy

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -14,11 +14,11 @@ void ProxyManager::unmanageProxy(ID id) {
 
 ProxyResult ProxyManager::getProxy(ID id) {
     auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
-    if (proxy_key_value->first == ProxyManager::singleton.proxy_map.end()) {
+    if (proxy_key_value != ProxyManager::singleton.proxy_map.end()) {
+        return proxy_key_value->second;
+    } else {
         const std::string msg = "Unknown Proxy ID: " + std::to_string(id);
         return libmexclass::error::Error{"libmexclass:proxy:UnknownID", msg};
-    } else {
-        return proxy_key_value->second;
     }
 }
 

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -13,7 +13,7 @@ void ProxyManager::unmanageProxy(ID id) {
 }
 
 ProxyResult ProxyManager::getProxy(ID id) {
-    auto proxy_key_value = ProxyManager::singleton.proxy_map.at(id);
+    auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
     if (proxy_key_value->first != ProxyManager::singleton.proxy_map.end()) {
         return proxy_key_value->second;
     } else {

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -12,15 +12,14 @@ void ProxyManager::unmanageProxy(ID id) {
     ProxyManager::singleton.proxy_map.erase(id);
 }
 
-//ProxyResult ProxyManager::getProxy(ID id) {
-//    auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
-//    if (proxy_key_value != ProxyManager::singleton.proxy_map.end()) {
-//        return proxy_key_value->second;
-//    } else {
-//        const std::string msg = "Unknown Proxy ID: " + std::to_string(id);
-//        return libmexclass::error::Error{"libmexclass:proxy:UnknownID", msg};
-//    }
-//}
+std::shared_ptr<Proxy> ProxyManager::getProxy(ID id) {
+    auto proxy_key_value = ProxyManager::singleton.proxy_map.find(id);
+    if (proxy_key_value != ProxyManager::singleton.proxy_map.end()) {
+        return proxy_key_value->second;
+    } else {
+        return nullptr;
+    }
+}
 
 ProxyManager ProxyManager::singleton{};
 } // namespace libmexclass::proxy


### PR DESCRIPTION
1. This PR fixes a bug in the `ProxyManager::getProxy` method. Because `ProxyManager::getProxy` uses `operator[]` to lookup IDs in the map, if the ID is not a key already, it will be added to the map. To fix this bug, we should `find` instead of `operator[]`. 

1. I also changed  `ProxyManager::getProxy` to return a `libmexclass::proxy::ProxyResult`, which is a `typedef` to `std::variant<std::shared_ptr<Proxy>, libmexclass::error::Error>`.


