### PR TITLE
Closes #64: Create a class to represent proxy ids

### DIFF
--- a/libmexclass/matlab/+libmexclass/+proxy/Identifier.m
+++ b/libmexclass/matlab/+libmexclass/+proxy/Identifier.m
@@ -1,4 +1,4 @@
-classdef ProxyID < matlab.mixin.Scalar
+classdef Identifier < matlab.mixin.Scalar
 
     properties(SetAccess=private, GetAccess=public)
         % C++ Proxy ID.
@@ -6,7 +6,7 @@ classdef ProxyID < matlab.mixin.Scalar
     end
 
     methods
-        function obj = ProxyID(id)
+        function obj = Identifier(id)
             if nargin == 1
                 validateattributes(id, {'numeric'}, ...
                     {'scalar', 'nonnegative', 'integer'});

--- a/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
+++ b/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
@@ -1,17 +1,21 @@
 classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
 
-    properties
+    properties(SetAccess=private, GetAccess=public)
         % C++ Proxy ID.
-        ProxyID(1, 1) libmexclass.proxy.ProxyID;
+        Identifier(1, 1) libmexclass.proxy.Identifier;
         % C++ Proxy Name.
         Name (1,1) string;
+    end
+
+    properties(Dependent)
+        ID
     end
 
     methods
 
         function obj = Proxy(options)
             arguments
-                options.ID (1,1) libmexclass.proxy.ProxyID {mustBeNonmissing}
+                options.ID (1,1) libmexclass.proxy.Identifier {mustBeNonmissing}
                 options.Name (1,1) string {mustBeNonmissing}
                 options.ConstructorArguments (1,:) cell
             end
@@ -23,14 +27,14 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
             obj.Name = options.Name;
 
             if isfield(options, "ID")
-                obj.ProxyID = options.ID;
+                obj.Identifier = options.ID;
             else
                 if ~isfield(options, "ConstructorArguments")
                     error("libmexclass:proxy:NoConstructorArguments", """ConstructorArguments"" must be specified when constructing a new Proxy instance.");
                 else
                     % Create the an instance of the specified C++ Proxy class and return its
                     % Proxy ID To be stored on the MATLAB Proxy object.
-                    obj.ProxyID = libmexclass.proxy.gateway("Create", options.Name, options.ConstructorArguments);
+                    obj.Identifier = libmexclass.proxy.gateway("Create", options.Name, options.ConstructorArguments);
                 end
             end
         end
@@ -40,9 +44,13 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
             % Destroy the corresponding C++ Proxy instance when destroying
             % the MATLAB object. ID may be empty if an error occured during
             % construction. If so, do not call destroy.
-            if ~ismissing(obj.ProxyID)
-                libmexclass.proxy.gateway("Destroy", obj.ProxyID.ID);
+            if ~ismissing(obj.Identifier)
+                libmexclass.proxy.gateway("Destroy", obj.ID);
             end
+        end
+
+        function id = get.ID(obj)
+            id = obj.Identifier.ID;
         end
     end
 
@@ -52,7 +60,7 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
                 op1 = indexOp(1);
                 methodArgs = indexOp(2).Indices;
                 methodName = string(op1.Name);
-                [varargout{1:nargout}] = libmexclass.proxy.gateway("MethodCall", obj.ProxyID.ID, methodName, methodArgs);
+                [varargout{1:nargout}] = libmexclass.proxy.gateway("MethodCall", obj.ID, methodName, methodArgs);
             end
         end
 

--- a/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
+++ b/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
@@ -2,7 +2,7 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
 
     properties
         % C++ Proxy ID.
-        ID uint64 = uint64.empty(0, 1);
+        ProxyID(1, 1) libmexclass.proxy.ProxyID;
         % C++ Proxy Name.
         Name (1,1) string;
     end
@@ -11,8 +11,8 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
 
         function obj = Proxy(options)
             arguments
-                options.ID (1,1) uint64
-                options.Name (1,1) string
+                options.ID (1,1) libmexclass.proxy.ProxyID {mustBeNonmissing}
+                options.Name (1,1) string {mustBeNonmissing}
                 options.ConstructorArguments (1,:) cell
             end
 
@@ -23,14 +23,14 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
             obj.Name = options.Name;
 
             if isfield(options, "ID")
-                obj.ID = options.ID;
+                obj.ProxyID = options.ID;
             else
                 if ~isfield(options, "ConstructorArguments")
                     error("libmexclass:proxy:NoConstructorArguments", """ConstructorArguments"" must be specified when constructing a new Proxy instance.");
                 else
                     % Create the an instance of the specified C++ Proxy class and return its
                     % Proxy ID To be stored on the MATLAB Proxy object.
-                    obj.ID = libmexclass.proxy.gateway("Create", options.Name, options.ConstructorArguments);
+                    obj.ProxyID = libmexclass.proxy.gateway("Create", options.Name, options.ConstructorArguments);
                 end
             end
         end
@@ -40,8 +40,8 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
             % Destroy the corresponding C++ Proxy instance when destroying
             % the MATLAB object. ID may be empty if an error occured during
             % construction. If so, do not call destroy.
-            if ~isempty(obj.ID)
-                libmexclass.proxy.gateway("Destroy", obj.ID);
+            if ~ismissing(obj.ProxyID)
+                libmexclass.proxy.gateway("Destroy", obj.ProxyID.ID);
             end
         end
     end
@@ -52,7 +52,7 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
                 op1 = indexOp(1);
                 methodArgs = indexOp(2).Indices;
                 methodName = string(op1.Name);
-                [varargout{1:nargout}] = libmexclass.proxy.gateway("MethodCall", obj.ID, methodName, methodArgs);
+                [varargout{1:nargout}] = libmexclass.proxy.gateway("MethodCall", obj.ProxyID.ID, methodName, methodArgs);
             end
         end
 
@@ -64,5 +64,4 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
             n = listLength(obj.AddedFields,indexOp,indexContext);
         end
     end
-
 end

--- a/libmexclass/matlab/+libmexclass/+proxy/ProxyID.m
+++ b/libmexclass/matlab/+libmexclass/+proxy/ProxyID.m
@@ -1,0 +1,21 @@
+classdef ProxyID < matlab.mixin.Scalar
+
+    properties(SetAccess=private, GetAccess=public)
+        % C++ Proxy ID.
+        ID = NaN
+    end
+
+    methods
+        function obj = ProxyID(id)
+            if nargin == 1
+                validateattributes(id, {'numeric'}, ...
+                    {'scalar', 'nonnegative', 'integer'});
+                obj.ID = uint64(id);
+            end
+        end
+
+        function tf = ismissing(obj)
+            tf = ismissing(obj.ID);
+        end
+    end
+end


### PR DESCRIPTION
Created a class called `libmexclass.proxy.Idenitifier` to represent proxy ids. The `libmexclass.proxy.Proxy` class stores an instance of this class instead of just a `uint64` to represent proxy ids. This class should help when creating proxy objects from existing ids.

> * Closes #64 