### PR TITLE
Closes #66: Add static "make"-style method called `create` to `Proxy`

### DIFF
--- a/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
+++ b/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
@@ -82,7 +82,7 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
                 arg
             end
             id = libmexclass.proxy.gateway("Create", name, arg);
-            proxy = libmexclass.proxy.Proxy(name=name, ID=id);
+            proxy = libmexclass.proxy.Proxy(Name=name, ID=id);
         end
     end
 end

--- a/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
+++ b/libmexclass/matlab/+libmexclass/+proxy/Proxy.m
@@ -72,4 +72,17 @@ classdef Proxy < matlab.mixin.indexing.RedefinesDot & handle
             n = listLength(obj.AddedFields,indexOp,indexContext);
         end
     end
+
+    methods(Static, Access = public)
+        function proxy = create(name, arg)
+            arguments
+                name(1, 1) string {mustBeNonmissing}
+            end
+            arguments(Repeating)
+                arg
+            end
+            id = libmexclass.proxy.gateway("Create", name, arg);
+            proxy = libmexclass.proxy.Proxy(name=name, ID=id);
+        end
+    end
 end


### PR DESCRIPTION
To support development workflows that require creating C++ proxies outside of the MATLAB `Proxy` constructor, we should add a static method called `create` to `Proxy`. 

```matlab
    methods(Static, Access = public)
        function proxy = create(name, args)
            arguments
                name(1, 1) string {mustBeNonmissing}
            end
            arguments(Repeating)
                arg
            end
            id = libmexclass.proxy.gateway("Create", name, args);
            proxy = libmexclass.proxy.Proxy(Name=name, ID=id);
        end
    end
```

This method abstracts the `gateway` function call.

This method makes it easier for clients to create MATLAB objects that "wrap" proxies from pre-existing proxies.