### PR TITLE
Closes #70: Recycle proxy ids after they are unmanaged

### DIFF
--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -47,14 +47,13 @@ class ProxyManager {
     static ProxyManager singleton;
     // The internal map used to associate Proxy instances with unique IDs.
     std::unordered_map<ID, std::shared_ptr<Proxy>> proxy_map;
-    
 
     // The next proxy id to hande out if recycled_ids is empty.
     ID current_proxy_id = 0;
 
     // A list of previously managed proxy ids that can be re-used.
-    // If this deque is not empty, manageProxy removes ID at the
-    // front of the deque to use as the next proxy ID.
+    // If this deque is not empty, manageProxy pops the ID from the
+    // front of the deque and uses it the next proxy ID.
     std::deque<ID> recycled_ids;
 
 };

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -48,14 +48,13 @@ class ProxyManager {
     // The internal map used to associate Proxy instances with unique IDs.
     std::unordered_map<ID, std::shared_ptr<Proxy>> proxy_map;
     
-    // TODO: Consider whether it makes sense to "recycle" deleted IDs:
-    //
-    // 1. Whenever an ID is deleted, enqueue it into an queue of recycled IDs.
-    // 2. The getNextId() method should first check if the queue has any
-    //    recycled IDs in it. If so, dequeue the first one and use it.
-    // 3. If the queue is empty, use the value of "current_id" and then
-    //    increment it.
+
+    // The next proxy id to hande out if recycled_ids is empty.
     ID current_proxy_id = 0;
+
+    // A list of previously managed proxy ids that can be re-used.
+    // If this deque is not empty, manageProxy removes ID at the
+    // front of the deque to use as the next proxy ID.
     std::deque<ID> recycled_ids;
 
 };

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -4,6 +4,7 @@
 #include "libmexclass/proxy/Proxy.h"
 #include "libmexclass/error/Error.h"
 
+#include <deque>
 #include <memory>
 #include <unordered_map>
 #include <variant>
@@ -41,10 +42,12 @@ class ProxyManager {
     }
 
   private:
+    ID getRecycledID();
+
     static ProxyManager singleton;
     // The internal map used to associate Proxy instances with unique IDs.
     std::unordered_map<ID, std::shared_ptr<Proxy>> proxy_map;
-
+    
     // TODO: Consider whether it makes sense to "recycle" deleted IDs:
     //
     // 1. Whenever an ID is deleted, enqueue it into an queue of recycled IDs.
@@ -53,6 +56,8 @@ class ProxyManager {
     // 3. If the queue is empty, use the value of "current_id" and then
     //    increment it.
     ID current_proxy_id = 0;
+    std::deque<ID> recycled_ids;
+
 };
 
 } // namespace libmexclass::proxy

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -53,7 +53,6 @@ class ProxyManager {
 
     // A list of previously managed proxy ids that can be re-used.
     // If there are recycled IDs available, then manageProxy will always use those first, before creating a new ID.
-    // front of the deque and uses it the next proxy ID.
     std::deque<ID> recycled_ids;
 
 };

--- a/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
+++ b/libmexclass/cpp/source/include/libmexclass/proxy/ProxyManager.h
@@ -52,7 +52,7 @@ class ProxyManager {
     ID current_proxy_id = 0;
 
     // A list of previously managed proxy ids that can be re-used.
-    // If this deque is not empty, manageProxy pops the ID from the
+    // If there are recycled IDs available, then manageProxy will always use those first, before creating a new ID.
     // front of the deque and uses it the next proxy ID.
     std::deque<ID> recycled_ids;
 

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -11,7 +11,7 @@ ID ProxyManager::getRecycledID() {
 ID ProxyManager::manageProxy(const std::shared_ptr<Proxy> &proxy) {
     const ID proxy_id = ProxyManager::singleton.recycled_ids.empty() 
       ? ProxyManager::singleton.current_proxy_id++
-      : ProxyManager.singleton.getRecycledID();
+      : ProxyManager::singleton.getRecycledID();
     ProxyManager::singleton.proxy_map[proxy_id] = proxy;
     return proxy_id;
 }

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -2,14 +2,23 @@
 
 namespace libmexclass::proxy {
 
+ID ProxyManager::getRecycledID() {
+  auto proxy_id = ProxyManager::singleton.recycled_ids.front();
+  ProxyManager::singleton.recycled_ids.pop_front();
+  return proxy_id;
+}
+
 ID ProxyManager::manageProxy(const std::shared_ptr<Proxy> &proxy) {
-    const ID proxy_id = ProxyManager::singleton.current_proxy_id++;
+    const ID proxy_id = ProxyManager::singleton.recycled_ids.empty() 
+      ? ProxyManager::singleton.current_proxy_id++
+      : ProxyManager.singleton.getRecycledID();
     ProxyManager::singleton.proxy_map[proxy_id] = proxy;
     return proxy_id;
 }
 
 void ProxyManager::unmanageProxy(ID id) {
     ProxyManager::singleton.proxy_map.erase(id);
+    ProxyManager::singleton.recycled_ids.push_back(id);
 }
 
 std::shared_ptr<Proxy> ProxyManager::getProxy(ID id) {

--- a/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
+++ b/libmexclass/cpp/source/libmexclass/proxy/ProxyManager.cpp
@@ -4,6 +4,7 @@ namespace libmexclass::proxy {
 
 ID ProxyManager::getRecycledID() {
   auto proxy_id = ProxyManager::singleton.recycled_ids.front();
+  // Remove the first recycled ID (which will be returned by getRecycledID) from the deque of recycled IDs.
   ProxyManager::singleton.recycled_ids.pop_front();
   return proxy_id;
 }


### PR DESCRIPTION
### Rationale

`libmexclass` should keep a list of "unmanaged" proxy IDs that can be reused. Currently, once a proxy ID is handed out, it cannot be reused even if the object associated with the ID has been deleted.

### Change

1. Added a new member variable called `recycled_ids` to `ProxyManager`. `recycled_ids` is a `std::deque<ID>`
2. `ProxyManager::unmanageProxy(ID)` pushes the unmanaged proxy ID to the back of `recycled_ids`.
3. `ProxyManager::manageProxy(proxy)` checks if `recycled_ids` is not empty. If so, it pops the first ID from `recycled_ids` and uses it as the ID for the newly managed proxy. Otherwise, it uses `current_proxy_id` as the new ID and increments `current_proxy_id` by one.

### Testing

Manually verified that `libmexclass` reuses proxy IDs if they are available. Otherwise, it creates new proxy IDs.