### PR TITLE
Closes #72: The `build.yml` GitHub Actions workflow fails on `macos-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
     mac:
-        runs-on: macos-latest
+        runs-on: macos-12
         env:
             LIBMEXCLASS_INSTALL_PREFIX: "~/install"
         steps:


### PR DESCRIPTION
### Description

The `build.yml` GitHub Actions workflow fails on `macos-latest` because `matlab-actions/setup-matlab@v1` is not supported on `arm64`. See the workflow run log [here](https://github.com/mathworks/libmexclass/actions/runs/8849001291/job/24299945946#step:3:14).

Note: `macos-latest` was recently bumped to `macos-14` from `macos-12`.

Unfortunately, while updating  both `matlab-actions/setup-matlab` and `matlab-actions/run-command` to `v2` resolves the initial error, the `build.yml` GitHub Action workflow fails on a later step. Specifically, the `Run Example` step fails due to a run-time linker issue.

As a temporary workaround, we should pin the mac GitHub runner back to `macos-12`. 

---

### Changes

1. Pinned the mac GitHub runner back to `macos-12`.

### Future Work

1. #73 
