### PR TITLE
Closes #73: Update `matlab-actions/setup-matlab` and `matlab-actions/run-command` to `v2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v3
             - name: Install MATLAB
-              uses: matlab-actions/setup-matlab@v2
+              uses: v2@v2
             - name: Build Example
               run: |
                   cd example
                   cmake -S . -B build -D CMAKE_INSTALL_PREFIX=${{ env.LIBMEXCLASS_INSTALL_PREFIX }} -D LIBMEXCLASS_FETCH_CONTENT_GIT_TAG=${{ github.sha }}
                   cmake --build build --config Release --target install
             - name: Run Example
-              uses: matlab-actions/run-command@v1
+              uses: matlab-actions/run-command@v2
               env:
                   # The version of libstdc++ that is bundled with MATLAB is used when building MEX files.
                   # This version of libstdc++ is incompatible with the system version of libstdc++.
@@ -33,14 +33,14 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v3
             - name: Install MATLAB
-              uses: matlab-actions/setup-matlab@v2
+              uses: v2@v2
             - name: Build Example
               run: |
                   cd example
                   cmake -S . -B build -D CMAKE_INSTALL_PREFIX=${{ env.LIBMEXCLASS_INSTALL_PREFIX }} -D LIBMEXCLASS_FETCH_CONTENT_GIT_TAG=${{ github.sha }}
                   cmake --build build --config Release --target install
             - name: Run Example
-              uses: matlab-actions/run-command@v1
+              uses: matlab-actions/run-command@v2
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
     windows:
@@ -53,7 +53,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v3
             - name: Install MATLAB
-              uses: matlab-actions/setup-matlab@v2
+              uses: v2@v2
             - name: Build Example
               run: |
                   cd example
@@ -61,6 +61,6 @@ jobs:
                   cmake -S . -B build -D CMAKE_INSTALL_PREFIX=${{ env.LIBMEXCLASS_INSTALL_PREFIX }} -D LIBMEXCLASS_FETCH_CONTENT_GIT_TAG=${{ github.sha }}
                   cmake --build build --config Release --target install
             - name: Run Example
-              uses: matlab-actions/run-command@v1
+              uses: matlab-actions/run-command@v2
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v3
             - name: Install MATLAB
-              uses: matlab-actions/setup-matlab@v1
+              uses: matlab-actions/setup-matlab@v2
             - name: Build Example
               run: |
                   cd example
@@ -33,7 +33,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v3
             - name: Install MATLAB
-              uses: matlab-actions/setup-matlab@v1
+              uses: matlab-actions/setup-matlab@v2
             - name: Build Example
               run: |
                   cd example
@@ -53,7 +53,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v3
             - name: Install MATLAB
-              uses: matlab-actions/setup-matlab@v1
+              uses: matlab-actions/setup-matlab@v2
             - name: Build Example
               run: |
                   cd example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v4
             - name: Install MATLAB
-              uses: v2@v2
+              uses: matlab-actions/setup-matlab@v2
             - name: Build Example
               run: |
                   cd example
@@ -33,7 +33,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v4
             - name: Install MATLAB
-              uses: v2@v2
+              uses: matlab-actions/setup-matlab@v2
             - name: Build Example
               run: |
                   cd example
@@ -53,7 +53,7 @@ jobs:
             - name: Download libmexclass source code
               uses: actions/checkout@v4
             - name: Install MATLAB
-              uses: v2@v2
+              uses: matlab-actions/setup-matlab@v2
             - name: Build Example
               run: |
                   cd example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
             SYSTEM_LIBSTDCPP_PATH: "/usr/lib/x86_64-linux-gnu/libstdc++.so.6"
         steps:
             - name: Download libmexclass source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Install MATLAB
               uses: v2@v2
             - name: Build Example
@@ -31,7 +31,7 @@ jobs:
             LIBMEXCLASS_INSTALL_PREFIX: "~/install"
         steps:
             - name: Download libmexclass source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Install MATLAB
               uses: v2@v2
             - name: Build Example
@@ -51,7 +51,7 @@ jobs:
             LIBMEXCLASS_GIT_TAG: ${{ vars.GITHUB_SHA }}
         steps:
             - name: Download libmexclass source code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Install MATLAB
               uses: v2@v2
             - name: Build Example


### PR DESCRIPTION
### Description

Update `matlab-actions/setup-matlab` and `matlab-actions/run-command` to `v2`. Currently, the `build.yml` workflow uses `v1` for both `matlab-actions/setup-matlab` and `matlab-actions/run-command`.  

### Changes

1. Updated `maltab-actions/setup-matlab` to `v2`
2. Updated `maltab-actions/run-command` to `v2` 
3. Updated `actions/checkout` to `v4`