### PR TITLE
Closes #76: Manually pass `matlab_add_mex` the required MEX libraries (e.g. `libmx`, `libmex`, and `libMatlabDataArray`) 

### DIFF
--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -244,8 +244,12 @@ macro(libmexclass_client_add_mex_gateway)
     matlab_add_mex(NAME ${LIBMEXCLASS_CLIENT_MEX_GATEWAY_NAME}
                    SRC ${LIBMEXCLASS_CLIENT_MEX_GATEWAY_SOURCES}
                    OUTPUT_NAME "gateway"
+                   NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
                    LINK_TO mexclass
-                           ${LIBMEXCLASS_CLIENT_MEX_GATEWAY_CLIENT_PROXY_LIBRARY_NAME})
+                           ${LIBMEXCLASS_CLIENT_MEX_GATEWAY_CLIENT_PROXY_LIBRARY_NAME}
+                           ${Matlab_MX_LIBRARY}
+                           ${Matlab_MEX_LIBRARY}
+                           ${Matlab_DATAARRAY_LIBRARY})
     # Set compiler features to require C++17.
     target_compile_features(${LIBMEXCLASS_CLIENT_MEX_GATEWAY_NAME} PRIVATE cxx_std_17)
     # Include directories (i.e. header files).

--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -241,6 +241,22 @@ macro(libmexclass_client_add_mex_gateway)
 
      MatlabConfigure()
 
+    # By default matlab_add_mex automatically links the output MEX function
+    # against all MEX-related libraries.
+    #
+    # These include: 
+    #  - libmx
+    #  - libmex
+    #  - libMatlabDataArray
+    #  - libMatlabEngine
+    #
+    # However, libMatlabEngine is only required for standalone C++ programs 
+    # that utilize the MATLAB Engine.
+    #
+    # Avoid linking against libMatlabEngine by supplying the
+    #  NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES flag and manually passing
+    # the required mex-related libraries as arguments for the LINK_TO parameter.
+    #
     matlab_add_mex(NAME ${LIBMEXCLASS_CLIENT_MEX_GATEWAY_NAME}
                    SRC ${LIBMEXCLASS_CLIENT_MEX_GATEWAY_SOURCES}
                    OUTPUT_NAME "gateway"


### PR DESCRIPTION
### Description

By default, the `matlab_add_mex` function automatically links the target MEX function against all MATLAB mex-related libraries:

- `libmx`
- `libmex`
- `libMatlabDataArray`
- `libMatlabEngine`

However, `libMatlabEngine` is only required for standalone C++ programs that utilize the MATLAB Engine. This library is not required for C++ MEX functions **and** linking against it causes run-time errors on `macos-14`. See [this log file](https://github.com/mathworks/libmexclass/actions/runs/8835481666/job/24259718536) for details. 

---

### Changes

1. Pass `NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES` flag to `matlab_add_mex`
2. Pass `libmex`, `libmx`, and `libmatlabdataarray` as arguments for the `LINK_TO` parameter