### PR TITLE
Closes #80: Use specific versions of GitHub-hosted runners (e.g. `ubuntu-22.04`) for GitHub Actions workflows rather than `-latest` variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
     windows:
-        runs-on: windows-latest
+        runs-on: windows-2022
         env:
             LIBMEXCLASS_INSTALL_PREFIX: ${{ vars.RUNNER_TEMP }}/install
             # Use the commit SHA that triggered the workflow to run the example on latest changes.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "libmexclass"
 on: [push]
 jobs:
     linux:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         env:
             LIBMEXCLASS_INSTALL_PREFIX: "/home/runner/work/install"
             SYSTEM_LIBSTDCPP_PATH: "/usr/lib/x86_64-linux-gnu/libstdc++.so.6"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
     mac:
-        runs-on: macos-12
+        runs-on: macos-14
         env:
             LIBMEXCLASS_INSTALL_PREFIX: "~/install"
         steps:


### PR DESCRIPTION
### Description

We have run into issues (e.g. https://github.com/mathworks/libmexclass/issues/72) because the build.yml GitHub Actions workflows currently uses the -latest variants (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) of the Windows, macOS, and Linux GitHub-hosted runners.

The `-latest` variants are a "moving target" and can change at any time.

We should instead use specific versions of each platform like `ubuntu-22.04` and `windows-2022`, rather than `ubuntu-latest` and `windows-latest`.

### Changes

1. Specify `ubuntu-22.04` as the GitHub-hosted runner for the `linux` job
2. Specify `macos-14` as the GitHub-hosted runner for the `mac` job
3. Specify `windows-2022` as the GitHub-hosted runner for the `windows` job