### PR TITLE
Closes #82: Explicitly specify the MATLAB version to use with `matlab-actions/setup-matlab` in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024
+                release: R2024a
             - name: Build Example
               run: |
                   cd example
@@ -37,7 +37,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024
+                release: R2024a
             - name: Build Example
               run: |
                   cd example
@@ -59,7 +59,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024
+                release: R2024a
             - name: Build Example
               run: |
                   cd example

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
               uses: actions/checkout@v4
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
+              with:
+                release: R2024
             - name: Build Example
               run: |
                   cd example
@@ -34,6 +36,8 @@ jobs:
               uses: actions/checkout@v4
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
+              with:
+                release: R2024
             - name: Build Example
               run: |
                   cd example
@@ -54,6 +58,8 @@ jobs:
               uses: actions/checkout@v4
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
+              with:
+                release: R2024
             - name: Build Example
               run: |
                   cd example


### PR DESCRIPTION
### Description 

Similar to https://github.com/mathworks/libmexclass/issues/80, we should explicitly specify the MATLAB version used in `build.yml` with `matlab-actions/setup-matlab` to avoid the MATLAB version automatically changing over time without any explicit qualification.

The MATLAB release can be specified via the release parameter for `matlab-actions/setup-matlab`:

https://github.com/matlab-actions/setup-matlab?tab=readme-ov-file#set-up-matlab

### Changes

1. Specified the MATLAB version to install as R2024a via the `release` parameter.