### PR TITLE
Closes #83: Pass `cache: true` to `matlab-actions/setup-matlab@v2` to speed up MATLAB installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
               uses: matlab-actions/setup-matlab@v2
               with:
                 release: R2024a
+                cache: true
             - name: Build Example
               run: |
                   cd example
@@ -38,6 +39,7 @@ jobs:
               uses: matlab-actions/setup-matlab@v2
               with:
                 release: R2024a
+                cache: true
             - name: Build Example
               run: |
                   cd example
@@ -60,6 +62,7 @@ jobs:
               uses: matlab-actions/setup-matlab@v2
               with:
                 release: R2024a
+                cache: true
             - name: Build Example
               run: |
                   cd example

--- a/README.md
+++ b/README.md
@@ -80,5 +80,3 @@ We welcome external contributions! Feel free to open a pull request!
 For more information, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Copyright &copy; 2022, The MathWorks, Inc.
-
-


### PR DESCRIPTION
### Description

In order to speed up installing MATLAB in the `build.yml` workflow,  we should pass `cache: true` to `matlab-actions/setup-matlab@v2`. See the [`matlab-actions/setup-matlab@v2` documentation](https://github.com/matlab-actions/setup-matlab?tab=readme-ov-file#set-up-matlab) for details. 

### Changes

1. Pass `cache: true` to `matlab-actions/setup-matlab@v2`