### PR TITLE
Closes #90: Use MATLAB R2024b in `build.yml`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024a
+                release: R2024b
                 cache: true
             - name: Build Example
               run: |
@@ -41,7 +41,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024a
+                release: R2024b
                 cache: true
             - name: Build Example
               run: |
@@ -64,7 +64,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024a
+                release: R2024b
                 cache: true
             - name: Build Example
               run: |


### PR DESCRIPTION
<!-- # Title -->

<!-- Pull request title format: -->
<!-- Closes #<issue-id>: <issue-title> -->
<!-- Example -->
<!-- Closes #86: Add cron job to build `libmexclass` nightly -->

# Issues

1. #90

# Implementation

1. Updated the `release` property for `matlab-actions/setup-matlab` to be `R2024b`.

# Qualification

1. `build.yml` workflow [passed successfully on all platforms](https://github.com/mathworks/libmexclass/actions/runs/11802589792).

# Future Directions

N/A

# Notes

1. Thanks @sgilmore10 for your help with this pull request!
