### PR TITLE
Closes #92: `libmexclass_client_add_proxy_library` should link the client proxy library against the `libmex` shared library

### DIFF
--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -208,6 +208,9 @@ macro(libmexclass_client_add_proxy_library)
     target_link_libraries(${LIBMEXCLASS_CLIENT_PROXY_LIBRARY_NAME} PRIVATE mexclass)
     # Link against MATLAB Data Array shared library.
     target_link_libraries(${LIBMEXCLASS_CLIENT_PROXY_LIBRARY_NAME} PRIVATE ${Matlab_DATAARRAY_LIBRARY})
+    # Link against Mex shared library.
+    target_link_libraries(${LIBMEXCLASS_CLIENT_PROXY_LIBRARY_NAME} PRIVATE ${Matlab_MEX_LIBRARY})
+
     
     define_property(
         TARGET

--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -208,7 +208,7 @@ macro(libmexclass_client_add_proxy_library)
     target_link_libraries(${LIBMEXCLASS_CLIENT_PROXY_LIBRARY_NAME} PRIVATE mexclass)
     # Link against MATLAB Data Array shared library.
     target_link_libraries(${LIBMEXCLASS_CLIENT_PROXY_LIBRARY_NAME} PRIVATE ${Matlab_DATAARRAY_LIBRARY})
-    # Link against Mex shared library.
+    # Link against MEX shared library.
     target_link_libraries(${LIBMEXCLASS_CLIENT_PROXY_LIBRARY_NAME} PRIVATE ${Matlab_MEX_LIBRARY})
 
     


### PR DESCRIPTION
<!-- # Title -->

<!-- Pull request title format: -->
<!-- Closes #<issue-id>: <issue-title> -->
<!-- Example -->
<!-- Closes #86: Add cron job to build `libmexclass` nightly -->

# Issues

<!-- Link(s) to associated issue(s) -->
<!-- Example -->
<!-- 1. #123 -->

1. #92 

# Implementation

<!-- Key notes on implementation and design choices -->
<!-- Example -->
<!-- 1. `ProxyFactory` uses the Factory Design Pattern ... -->

1. Updated `libmexclass_client_add_proxy_library` to link the client shared library against `libmex`.  

# Qualification

<!-- Description of qualification efforts -->
<!-- Example -->
<!-- 1. Added new MATLAB test class `ProxyFactoryTest` ... -->

1. build.yml workflow [passed successfully on all platforms](https://github.com/mathworks/libmexclass/actions/runs/11805250036)

# Future Directions

<!-- Next steps and related issues -->
<!-- Example -->
<!-- 1. #456 -->

N/A

# Notes

<!-- Important notes, attributions, etc. -->
<!-- Example -->
<!-- 1. Thanks @<username> for your help with this pull request! -->

Thanks for the help @kevingurney! 
