### PR TITLE
Closes #94: Update `cmake_minimum_required` to `3.6` for compatibility with CMake 4.0.0

### DIFF
--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Required for CMake version 4.0.0
 cmake_minimum_required(VERSION 3.6.0)
 
 # CMake policy CM0074 must be set explicitly by any client project 

--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Required for CMake version 4.0.0
 cmake_minimum_required(VERSION 3.6.0)
 
 # CMake policy CM0074 must be set explicitly by any client project 

--- a/libmexclass/cpp/CMakeLists.txt
+++ b/libmexclass/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.6.0)
 
 # CMake policy CM0074 must be set explicitly by any client project 
 # that wants to use find_package with a <PACKAGE>_ROOT variable. 


### PR DESCRIPTION
# Issues

#94 : Update `cmake_minimum_required` to `3.6` for compatibility with CMake 4.0.0

# Implementation

1. Set `cmake_minimum_required` to `3.6`.

# Qualification

GitHub Actions Run: https://github.com/mathworks/libmexclass/actions/runs/14268094691
