### PR TITLE
Closes #96: Bump `matlab-actions/setup-matlab` to R2025a

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024b
+                release: R2025a
                 cache: true
             - name: Build Example
               run: |
@@ -41,7 +41,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024b
+                release: R2025a
                 cache: true
             - name: Build Example
               run: |
@@ -64,7 +64,7 @@ jobs:
             - name: Install MATLAB
               uses: matlab-actions/setup-matlab@v2
               with:
-                release: R2024b
+                release: R2025a
                 cache: true
             - name: Build Example
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,4 +76,3 @@ jobs:
               uses: matlab-actions/run-command@v2
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,4 @@ jobs:
               uses: matlab-actions/run-command@v2
               with:
                   command: addpath(fullfile("${{ env.LIBMEXCLASS_INSTALL_PREFIX }}")), addpath(fullfile("example", "matlab")), c = example.Car("A", "B", "C")
+


### PR DESCRIPTION
<!-- # Title -->
# Issues
#96: Bump `matlab-actions/setup-matlab` to R2025a

# Implementation

Set MATLAB version to R2025a via `matlab-actions/setup-matlab`.

# Qualification

GitHub Actions Run: https://github.com/mathworks/libmexclass/actions/runs/15741917220
